### PR TITLE
Working docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby
+MAINTAINER Tim Perry <pimterry@gmail.com>
+
+USER root
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    # Set password to temp-password - reset to random password on startup
+    echo mysql-server mysql-server/root_password password temp-password | debconf-set-selections && \
+    echo mysql-server mysql-server/root_password_again password temp-password | debconf-set-selections && \   
+    # Instal MySQL for data, node as the JS engine for uglifier
+    apt-get install -y mysql-server nodejs
+    
+COPY . /opt/staytus
+
+RUN cd /opt/staytus && \
+    bundle install --deployment --without development:test
+
+ENTRYPOINT /opt/staytus/docker-start.sh
+
+# Persists all DB state
+VOLUME /var/lib/mysql
+
+# Persists copies of other relevant files (DB config, custom themes). Contents of this are copied 
+# to the relevant places each time the container is started
+VOLUME /opt/staytus/persisted
+
+EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -12,13 +12,36 @@ any organization with customers that rely on them to be online 24/7.
 
 ![Screenshot](https://s.adamcooke.io/15/iOzvtk.png)
 
-## System Requirements
+## Setup with Docker
+
+1. [Install Docker locally](https://docs.docker.com/installation/)
+2. Run `docker run -d -p 80:5000 --name=staytus adamcooke/staytus`
+3. Go to [http://localhost:80](http://localhost:80) and follow the instructions to configure Staytus
+
+This will pull and start the latest published Staytus docker container, and start it listening on port 80 on the host machine.
+
+Note that this container includes two persistent volumes, one for the database (persisting all config and state) and one for persistent DB config.
+
+### Upgrading with Docker
+
+When a new Staytus Docker image is published that you'd like to upgrade to:
+
+1. Stop your current Staytus container with `docker stop staytus`
+2. Rename your previous container with `docker rename staytus staytus-old`
+3. Start a new container, reusing your previous volumes, with `docker run -d -p 80:5000 --name=staytus --volumes-from=staytus-old adamcooke/staytus`
+4. Delete the old container with `docker rm staytus-old`
+
+This will automatically migrate your DB to pick up any new changes, and bring in any new code changes from the Staytus code. 
+
+## Manual setup
+
+### System Requirements
 
 * Ruby 2.1 or greater
 * RubyGems and Bundler
 * A MySQL database server
 
-## Installation from source
+### Installation from source
 
 Currently the only way to install Stayus is from the source repository.
 To do this, you'll need Git installed.

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+/etc/init.d/mysql start
+cd /opt/staytus
+
+# Configure DB with random password, if not already configured
+if [ ! -f /opt/staytus/persisted/config/database.yml ]; then
+  export RANDOM_PASSWORD=`openssl rand -base64 32`
+
+  mysqladmin -u root -ptemp-password password $RANDOM_PASSWORD
+  echo "CREATE DATABASE staytus CHARSET utf8 COLLATE utf8_unicode_ci" | mysql -u root -p$RANDOM_PASSWORD
+
+  cp config/database.example.yml config/database.yml
+  sed -i "s/username:.*/username: root/" config/database.yml
+  sed -i "s|password:.*|password: $RANDOM_PASSWORD|" config/database.yml
+
+  # Copy the config to persist it, and later copy back on each start, to persist this config file 
+  # without persisting all of /config (which is mostly app code)
+  mkdir /opt/staytus/persisted/config
+  cp config/database.yml /opt/staytus/persisted/config/database.yml
+
+  bundle exec rake staytus:build staytus:install
+else
+  # Use the previously saved config from the persisted volume
+  cp /opt/staytus/persisted/config/database.yml config/database.yml
+  # TODO also copy themes back and forth too
+
+  # If already configured, check if there are any migrations to run
+  bundle exec rake staytus:build staytus:upgrade
+fi
+
+bundle exec foreman start


### PR DESCRIPTION
This fixes #19.

This changes includes a Dockerfile (defining how to build the docker image), and a script that's run by the docker container each time it's started. That script initially generates a DB password and does initial app setup, and then persists the resulting config, and subsequently restores the persisted config, and checks to see if any migrations are required.

This doesn't yet support persisting custom themes you add, but I don't think that'd be too hard, I just haven't got to it yet, and this is a good to start for now.

To test this:
1. Pull this PR down locally
2. Install docker locally
3. Run `docker build .` in the root of the project, to generate the image (this will save the files in the current directory as the initial state for the image)
4. Start a docker container from that image, following the instructions now in the readme, using the hash of the built container instead of `adamcooke/staytus` (which isn't a published image, yet). 

I've only tested this locally, so there might be some teething problems, but give that a go and see what happens. You should end up with a staytus app running on localhost:80.

If that works and you're happy with this, the next step is to create an account on [Docker Hub](https://hub.docker.com/account/signup/) and push the built image to it, so that other people can just reference `adamcooke/staytus` to download and run it.

To keep that up to date you'll need to then publish a new image when you release new versions. You can easily automate that though if you want, to get Docker Hub to automatically build and publish new images everytime you change master. See https://docs.docker.com/docker-hub/builds/.