### PR TITLE
Update docker instructions to listen on *

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ processes which you have running.
 ## Setup with Docker
 
 1. [Install Docker locally](https://docs.docker.com/installation/)
-2. Run `docker run -d -p 80:5000 --name=staytus adamcooke/staytus`
+2. Run `docker run -d -p 0.0.0.0:80:5000 --name=staytus adamcooke/staytus`
 3. Go to [http://localhost:80](http://localhost:80) and follow the instructions to configure Staytus
 
 This will pull and start the latest published Staytus docker container, and start it listening on port 80 on the host machine.
@@ -75,7 +75,7 @@ When a new Staytus Docker image is published that you'd like to upgrade to:
 
 1. Stop your current Staytus container with `docker stop staytus`
 2. Rename your previous container with `docker rename staytus staytus-old`
-3. Start a new container, reusing your previous volumes, with `docker run -d -p 80:5000 --name=staytus --volumes-from=staytus-old adamcooke/staytus`
+3. Start a new container, reusing your previous volumes, with `docker run -d -p 0.0.0.0:80:5000 --name=staytus --volumes-from=staytus-old adamcooke/staytus`
 4. Delete the old container with `docker rm staytus-old`
 
 This will automatically migrate your DB to pick up any new changes, and bring in any new code changes from the Staytus code.


### PR DESCRIPTION
Finishing up #23 to catch the point you mentioned (about exposing the server port externally). This updates the instructions to make sure the server starts up listening on all interfaces, not just localhost. 

With this you should be able to now just install docker and run the one command, and have a working staytus instance up and ready to go a minute later.