### PR TITLE
Use site.domain_with_protocol rather than site.domain in default templates

### DIFF
--- a/app/views/emails/new_issue.txt
+++ b/app/views/emails/new_issue.txt
@@ -2,7 +2,7 @@
 
 Full details can be seen below. We will continue to post updated whenever they become available.
 
-[View on the status site](http://{{site.domain}}/issue/{{issue.identifier}})
+[View on the status site]({{site.domain_with_protocol}}/issue/{{issue.identifier}})
 
 ## {{issue.title}}
 

--- a/app/views/emails/new_issue_update.txt
+++ b/app/views/emails/new_issue_update.txt
@@ -2,7 +2,7 @@
 
 Full details can be seen below. We will continue to post updated whenever they become available.
 
-[View on the status site](http://{{site.domain}}/issue/{{issue.identifier}}#{{update.identifier}})
+[View on the status site]({{site.domain_with_protocol}}/issue/{{issue.identifier}}#{{update.identifier}})
 
 ## {{issue.title}}
 

--- a/app/views/emails/new_maintenance.txt
+++ b/app/views/emails/new_maintenance.txt
@@ -1,6 +1,6 @@
 # A new maintenance session has been announced on {{site.title}}
 
-[View on the status site](http://{{site.domain}}/maintenance/{{maintenance.identifier}})
+[View on the status site]({{site.domain_with_protocol}}/maintenance/{{maintenance.identifier}})
 
 ## {{maintenance.title}}
 

--- a/app/views/emails/new_maintenance_update.txt
+++ b/app/views/emails/new_maintenance_update.txt
@@ -1,6 +1,6 @@
 # A maintenance session has been updated on {{site.title}}
 
-[View on the status site](http://{{site.domain}}/maintenance/{{maintenance.identifier}})
+[View on the status site]({{site.domain_with_protocol}}/maintenance/{{maintenance.identifier}})
 
 ## {{maintenance.title}}
 

--- a/app/views/emails/subscribed.txt
+++ b/app/views/emails/subscribed.txt
@@ -2,6 +2,6 @@
 
 You recently opted to receive e-mail notifications from {{site.title}}. In order to send these messages, please click the link below to verify that you own this e-mail address.
 
-[Click here to verify your address](http://{{site.domain}}/verify/{{subscriber.verification_token}})
+[Click here to verify your address]({{site.domain_with_protocol}}/verify/{{subscriber.verification_token}})
 
 If you did not request this or no longer with wish to receive these notifications, you can just ignore this e-mail.

--- a/content/themes/default/views/email.html
+++ b/content/themes/default/views/email.html
@@ -40,7 +40,7 @@
   <td class='footer'>
     <p>
       You have received this e-mail because you have subscribed to {{site.title}}.
-      If you'd like to stop receiving these messages, you can <a href='http://{{site.domain}}/unsub/{{subscriber.verification_token}}'>click here</a>
+      If you'd like to stop receiving these messages, you can <a href='{{site.domain_with_protocol}}/unsub/{{subscriber.verification_token}}'>click here</a>
       and we'll stop sending messages straight away.
     </p>
   </td>


### PR DESCRIPTION
Thanks for closing #53. Now that `site.domain_with_protocol` is customisable, it makes sense to use it in the default email templates.