### PR TITLE
Add foreman-export-initscript.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'moonrope', '~> 1.3'
 gem 'florrick', '~> 1.1'
 gem 'delayed_job_active_record'
 gem 'foreman'
+gem 'foreman-export-initscript'
 gem 'redcarpet', '~> 3.2.2'
 gem 'premailer', '~> 1.8.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     foreman (0.77.0)
       dotenv (~> 1.0.2)
       thor (~> 0.19.1)
+    foreman-export-initscript (0.0.1)
+      foreman
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.6)
@@ -221,6 +223,7 @@ DEPENDENCIES
   dynamic_form
   florrick (~> 1.1)
   foreman
+  foreman-export-initscript
   haml (~> 4.0.5)
   jquery-rails
   kaminari (~> 0.16.1)
@@ -240,4 +243,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.2


### PR DESCRIPTION
Add foreman extension for generation of LSB-compatibile SysV initscript. Quite handy for legacy standalone (non-docker) deployments.