### PR TITLE
Fixes #119 remove am pm after 24hr time on maintenance page

### DIFF
--- a/content/themes/default/views/pages/maintenance.html.erb
+++ b/content/themes/default/views/pages/maintenance.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <h1 class='issueDetail__title'><%= @maintenance.title %></h1>
-  <p class='issueDetail__date'>Scheduled for <%= @maintenance.start_at.strftime("%A #{@maintenance.start_at.day.ordinalize} %B %Y at %H:%M%P (#{site.time_zone})") %></p>
+  <p class='issueDetail__date'>Scheduled for <%= @maintenance.start_at.strftime("%A #{@maintenance.start_at.day.ordinalize} %B %Y at %H:%M (#{site.time_zone})") %></p>
   <p class='issueDetail__descriptionTitle'>Schedule/description of work</p>
   <p class='issueDetail__description'><%= @maintenance.description %></p>
 


### PR DESCRIPTION
Removes am/pm from maintenance page reported in #119 

Time of maintenance window is always converted to 24hr format so am/pm appears to just be legacy? 