### PR TITLE
Allow setting ENV for stmp HELO

### DIFF
--- a/config/environment.example.yml
+++ b/config/environment.example.yml
@@ -17,3 +17,7 @@ STAYTUS_SMTP_HOSTNAME: smtp.deliverhq.com
 STAYTUS_SMTP_PORT: '25'
 STAYTUS_SMTP_USERNAME: your-username
 STAYTUS_SMTP_PASSWORD: your-password
+
+
+# Optional requirement for services that require you to set a domain value. example: mailgun
+# STAYTUS_SMTP_DOMAIN:  example.net

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -6,7 +6,8 @@ if ENV['STAYTUS_SMTP_HOSTNAME']
     :user_name              => ENV['STAYTUS_SMTP_USERNAME'],
     :password               => ENV['STAYTUS_SMTP_PASSWORD'],
     :authentication         => ENV['STAYTUS_SMTP_AUTH_MODE'],
-    :enable_starttls_auto   => ENV['STAYTUS_SMTP_STARTTLS'] == '1'
+    :enable_starttls_auto   => ENV['STAYTUS_SMTP_STARTTLS'] == '1',
+    :domain                 => ENV['STAYTUS_SMTP_DOMAIN'],
   }
 else
   puts "\e[33m=> You haven't configured an SMTP server. Mail will be sent using sendmail.\e[0m"


### PR DESCRIPTION
This should allow access to the HELO setting in the smtp_setting hash. 3rd party systems require this (mailgun for example)