### PR TITLE
+ added the abilty to view only 1 service group at a time via a url e…

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
   post 'subscribe/email' => 'pages#subscribe_by_email'
   get 'unsub/:token' => 'pages#unsubscribe'
   get 'verify/:token' => 'pages#subscriber_verification'
+  get 'service-group/:service_group' => 'pages#service_group'
   root 'pages#index'
 
 end


### PR DESCRIPTION
This should create an enpoint only to show one service group.
http://statyus/service-groups/:group_name

if not a valid group or a group with no services, then redirect to the `:root` of the project