### PR TITLE
Add maintenances API

### DIFF
--- a/api/controllers/maintenances_api_controller.rb
+++ b/api/controllers/maintenances_api_controller.rb
@@ -1,0 +1,31 @@
+controller :maintenances do
+  
+    action :all do
+      action do
+        Maintenance.ordered.includes(:services).map do |s|
+          structure(s, :full => true, :expansions => [:services])
+        end
+      end
+    end
+
+    action :info do
+      param :maintenance, :required => true, :type => Integer
+      action do
+        maintenance = Maintenance.find_by_id(params.maintenance)
+        unless maintenance
+          error :not_found, "Maintenance not found with ID `#{params.maintenance}`"
+        end
+        structure(maintenance, :full => true, :expansions => true)
+      end
+    end
+
+    action :upcoming do
+      action do
+        Maintenance.ordered.where("start_at > NOW()").includes(:services).map do |s|
+          structure(s, :full => true, :expansions => [:services])
+        end
+      end
+    end
+  
+  end
+  

--- a/api/structures/maintenance_api_structure.rb
+++ b/api/structures/maintenance_api_structure.rb
@@ -1,0 +1,15 @@
+structure :maintenance do
+  basic :id
+  basic :title
+  full :description
+  full :start_at
+  full :finish_at
+  full :length_in_minutes
+  full :created_at
+  full :updated_at
+
+  expansion :services
+
+  expansion :updates
+
+end

--- a/api/structures/maintenance_api_structure.rb
+++ b/api/structures/maintenance_api_structure.rb
@@ -7,6 +7,7 @@ structure :maintenance do
   full :length_in_minutes
   full :created_at
   full :updated_at
+  full :identifier
 
   expansion :services
 

--- a/doc/api/maintenances_api.md
+++ b/doc/api/maintenances_api.md
@@ -1,0 +1,67 @@
+# Staytus Maintenances API
+
+The maintenances API allows you to access maintenances that are present in your Staytus site.
+
+## Listing all issues
+
+```text
+/api/v1/maintenances/all
+```
+
+This method accepts no parameters and will return an array of
+all maintenances. The method will return an array of service objects affected by that maintenance.
+
+## Listing all upcoming issues
+
+```text
+/api/v1/maintenances/upcoming
+```
+
+This method accepts no parameters and will return an array of maintenances that are due. The method will return an array of service objects affected by that maintenance.
+
+
+## Retrieving individual maintenance details
+
+```text
+/api/v1/maintenances/info
+```
+
+* `maintenance` - the ID for the maintenance you wish to lookup
+
+```javascript
+{
+    "id": 1,
+    "title": "A title",
+    "description": "A description.",
+    "start_at": "2017-11-08T14:00:00.000Z",
+    "finish_at": "2017-11-08T15:00:00.000Z",
+    "length_in_minutes": 60,
+    "created_at": "2017-11-07T13:38:22.000Z",
+    "updated_at": "2017-11-07T13:43:37.000Z",
+    "services": [
+        {
+            "id": 1,
+            "name": "Web Application",
+            "permalink": "web-application",
+            "position": 1,
+            "created_at": "2017-11-07T13:37:32.000Z",
+            "updated_at": "2017-11-07T13:37:32.000Z",
+            "status_id": 1,
+            "description": null,
+            "group_id": null
+        }
+    ],
+    "updates": [
+        {
+            "id": 1,
+            "maintenance_id": 1,
+            "user_id": 1,
+            "text": "We are still hard at work!",
+            "created_at": "2017-11-07T13:43:37.000Z",
+            "updated_at": "2017-11-07T13:43:37.000Z",
+            "identifier": "b7783b8845bb",
+            "notify": false
+        }
+    ]
+}
+```


### PR DESCRIPTION
This PR adds resources to the API for retrieving maintenance info. The standard ```/all``` and ```/info``` have been added as well as a ```/upcoming```  which will return all maintenance's that have yet to take place.

Documentation has been added.