### PR TITLE
Fix robots.txt in Rails 5.1.x

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -31,7 +31,7 @@ class PagesController < ApplicationController
     unless site.crawling_permitted?
       text << "Disallow: /"
     end
-    render :text => text.join("\n"), :content_type => 'text/plain'
+    render :plain => text.join("\n"), :content_type => 'text/plain'
   end
 
   def subscriber_verification


### PR DESCRIPTION
I was getting a 500 series error whenever attempting to load the robots.txt for Staytus. Looks like Rails 5.1 deprecated the `text` option for ActionView's render method. Switched this to `plain` and things are working as expected.