### PR TITLE
Initial markdown support for issue and maintenance text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,9 @@ module ApplicationHelper
     end
   end
 
+  def markdown(text)
+    md = Redcarpet::Markdown.new(Redcarpet::Render::Safe)
+    return md.render(text).html_safe
+  end
+
 end

--- a/content/themes/default/views/pages/issue.html.erb
+++ b/content/themes/default/views/pages/issue.html.erb
@@ -21,10 +21,10 @@
     <% @updates.each do |update| %>
     <div class='issueUpdates__update'>
       <a name='update-<%=update.identifier%>'></a>
-      <p class='issueUpdates__text'>
+      <div class='issueUpdates__text'>
         <b class='issueUpdate__state issueUpdate__state--<%= update.state %>'><%= update.state.humanize %></b> &mdash;
-        <%= update.text %>
-      </p>
+        <%= markdown(update.text) %>
+      </div>
       <p class='issueUpdates__meta'>
         Posted <%= time_tag update.created_at%>
         <% if update.user %>by <%= update.user.name %><% end %>

--- a/content/themes/default/views/pages/maintenance.html.erb
+++ b/content/themes/default/views/pages/maintenance.html.erb
@@ -17,7 +17,7 @@
   <h1 class='issueDetail__title'><%= @maintenance.title %></h1>
   <p class='issueDetail__date'>Scheduled for <%= @maintenance.start_at.strftime("%A #{@maintenance.start_at.day.ordinalize} %B %Y at %H:%M (#{site.time_zone})") %></p>
   <p class='issueDetail__descriptionTitle'>Schedule/description of work</p>
-  <p class='issueDetail__description'><%= @maintenance.description %></p>
+  <div class='issueDetail__description'><%= markdown(@maintenance.description) %></div>
 
   <dl class='issueDetail__details'>
     <dt>Scheduled start time</dt>
@@ -35,9 +35,9 @@
     <% @updates.each do |update| %>
     <div class='issueUpdates__update'>
       <a name='update-<%=update.identifier%>'></a>
-      <p class='issueUpdates__text'>
-        <%= update.text %>
-      </p>
+      <div class='issueUpdates__text'>
+        <%= markdown(update.text) %>
+      </div>
       <p class='issueUpdates__meta'>
         Posted <%= time_tag update.created_at%>
         <% if update.user %>by <%= update.user.name %><% end %>


### PR DESCRIPTION
This is a lightly tested change to apply markdown filtering to the text of issues and maintenance entries. This should be progress towards #124.

The CSS will also need to be updated for normal-looking output. CSS is currently clearing the list style, for example.

Note that the `<p>` tags wrapping the issue detail were swapped to `<div>`. The markdown output contains `<p>`, which should not be nested.