### PR TITLE
Fix type error when starting application

### DIFF
--- a/config/environment.example.yml
+++ b/config/environment.example.yml
@@ -19,4 +19,4 @@ STAYTUS_SMTP_USERNAME: your-username
 STAYTUS_SMTP_PASSWORD: your-password
 
 # Configure SSL to be forced (ensuring HSTS headers are sent and cookies are all secure)
-FORCE_SSL: 1
+FORCE_SSL: '1'


### PR DESCRIPTION
Hi,

this PR fixes a `TypeError: no implicit conversion of Integer into String` error when starting the application after copying the `environment.yml` from the example file.

Additionally it would be nice if you could either add the `hacktoberfest-accepted` label to this PR so it counts as a contribution to [Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) or add the `hacktoberfest` topic to the project.