### PR TITLE
Add german translation

### DIFF
--- a/content/locales/de.yml
+++ b/content/locales/de.yml
@@ -1,0 +1,21 @@
+de:
+  # You can add additional locale definitions in here if you need to
+  # override anything.
+  themes:
+    default:
+      footer:
+        history: "Verlauf"
+        homepage: "Unsere Website"
+        privacy_policy: "Privatsphäre"
+        contact_us: "Kontakt"
+        powered_by: "Ermöglicht durch"
+      history:
+        title: "Vorfall- und Wartungsverlauf"
+        intro: "Diese Seite zeigt alle momentanen und vergangenen Vorfälle und Wartungsarbeiten."
+      last_updated: "zuletzt aktualisiert"
+      maintenance: "Wartungsarbeiten"
+      due_to_finish: "wird abgeschlossen"
+      due_to_start: "wird gestartet"
+      subscribe:
+        title: "Aktualisierungen abonnieren"
+        intro: "Wählen Sie aus den folgenden Optionen, um automatisch Benachrichtigungen zu erhalten, wenn es neue Vorfälle gibt."

--- a/content/locales/en.yml
+++ b/content/locales/en.yml
@@ -3,4 +3,19 @@ en:
   # override anything.
   themes:
     default:
-      hello: Hello world!
+      footer:
+        history: "History"
+        homepage: "Our Homepage"
+        privacy_policy: "Privacy Policy"
+        contact_us: "Contact Us"
+        powered_by: "Powered By"
+      history:
+        title: "Issue & Maintenance History"
+        intro: "This page shows all current & historical issues & maintenance sessions."
+      last_updated: "last updated"
+      maintenance: "Maintenance"
+      due_to_finish: "due to finish"
+      due_to_start: "due to start"
+      subscribe:
+        title: "Subscribe for updates"
+        intro: "Choose from the options below to automatically receive notifications when we update the status site."


### PR DESCRIPTION
Hi, 

this PR adds the i18n values currently used in the `.erb` templates to `en.yml`.
Additionally the i18n was translated to german.

Same as #330, it would be nice if you could either add the `hacktoberfest-accepted` label to this PR so it counts as a contribution to [Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) or add the `hacktoberfest` topic to the project.