### PR TITLE
Remove invalid templating in email

### DIFF
--- a/content/themes/default/views/email.html
+++ b/content/themes/default/views/email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name='Generator' content='Staytus/<%= Staytus::Config.version %>' />
+<meta name='Generator' content='Staytus' />
 <style type="text/css">
   html, body { background:#F6FBFF;}
   * { color:#2B3034; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif; font-size:14px; }


### PR DESCRIPTION
Hi,

this PR removes invalid template escaping in the `email.html` file.
Since this file is not a template, `<%= Staytus::Config.version %>` will result in `&lt;%= Staytus::Config.version %&gt;` in the final mail.

Same as #330 and #331, it would be nice if you could either add the `hacktoberfest-accepted` label to this PR so it counts as a contribution to [Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) or add the `hacktoberfest` topic to the project.