### PR TITLE
Show service group on issue page (and admin area)

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -12,7 +12,11 @@
     %table.dashboardServiceStatusTable
       - for service in @services
         %tr
-          %td.name= service.name
+          %td.name
+            - label = service.name
+            - if service.group
+              - label += " (#{service.group.name})"
+            = label
           %td= service_status_tag(service, :link_maintenance => :admin)
   .col.col--8
     %a.dashboardButton.dashboardButton--issue.u-margin{:href => new_admin_issue_path}

--- a/app/views/admin/issues/_form.html.haml
+++ b/app/views/admin/issues/_form.html.haml
@@ -22,8 +22,11 @@
         %ul.fieldSet__checkboxList
           - for service in Service.ordered
             %li
+              - checkbox_label = service.name
+              - if service.group
+                - checkbox_label += " (#{service.group.name})"
               = check_box_tag 'issue[service_ids][]', service.id, @issue.services.include?(service), :id => "service_#{service.id}"
-              = label_tag "service_#{service.id}", service.name
+              = label_tag "service_#{service.id}", checkbox_label
 
     - if @issue.new_record?
       %dl.fieldSet__field.u-margin

--- a/app/views/admin/maintenances/_form.html.haml
+++ b/app/views/admin/maintenances/_form.html.haml
@@ -29,8 +29,11 @@
         %ul.fieldSet__checkboxList
           - for service in Service.ordered
             %li
+              - checkbox_label = service.name
+              - if service.group
+                - checkbox_label += " (#{service.group.name})"
               = check_box_tag 'maintenance[service_ids][]', service.id, @maintenance.services.include?(service), :id => "service_#{service.id}"
-              = label_tag "service_#{service.id}", service.name
+              = label_tag "service_#{service.id}", checkbox_label
 
     %dl.fieldSet__field.u-margin
       %dt.fieldSet__label= f.label :service_status_id, "Which status should be displayed for these status when this session is active?"

--- a/app/views/admin/services/index.html.haml
+++ b/app/views/admin/services/index.html.haml
@@ -12,6 +12,10 @@
   %tbody
     - for service in @services
       %tr
-        %td= link_to service.name, [:edit, :admin, service], :class => 'u-underline'
+        %td
+          - link_label = service.name
+          - if service.group
+            - link_label += " (#{service.group.name})"
+          = link_to link_label, [:edit, :admin, service], :class => 'u-underline'
         %td= service_status_tag service, :link_maintenance => :admin
         %td.u-align-right= link_to "Edit", [:edit, :admin, service], :class => 'button button--small'

--- a/content/themes/default/views/pages/issue.html.erb
+++ b/content/themes/default/views/pages/issue.html.erb
@@ -8,7 +8,12 @@
     <p>Affected services:</p>
     <ul>
       <% @issue.services.each do |service| %>
-      <li><%= service.name %></li>
+          <li>
+            <%= service.name %>
+            <% if service.group %>
+            (<%= service.group.name %>)
+            <% end %>
+          </li>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
Hi,

this PR adds the service name in parentheses to the affected services list on the issue page, the admin dashboard and the admin service list.

This prevents confusion when there are multiple services with the same name in different groups.

Same as #330, #331 and #332, it would be nice if you could either add the `hacktoberfest-accepted` label to this PR so it counts as a contribution to [Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) or add the `hacktoberfest` topic to the project so all PRs opened in during Hacktoberfest count for it.
 