### PR TITLE
Service subscribers

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -54,7 +54,7 @@ class PagesController < ApplicationController
   end
 
   def subscribe_by_email
-    @subscriber = Subscriber.new(:email_address => params[:email_address])
+    @subscriber = Subscriber.new(:email_address => params[:email_address], :service_ids => params[:service_ids])
     if @subscriber.save
       @subscriber.send_verification_email
       redirect_to root_path, :notice => "Thanks - please check your email and click the link within to confirm your subscription."

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -81,7 +81,7 @@ class Issue < ActiveRecord::Base
   end
 
   def subscribers
-    Subscriber.for_services(service_ids)
+    @subscribers ||= Subscriber.for_services(service_ids)
   end
 
   def send_notifications

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -80,8 +80,12 @@ class Issue < ActiveRecord::Base
     end
   end
 
+  def subscribers
+    Subscriber.for_services(service_ids)
+  end
+
   def send_notifications
-    for subscriber in Subscriber.verified
+    for subscriber in subscribers
       Staytus::Email.deliver(subscriber, :new_issue, :issue => self, :update => self.updates.order(:id).first)
     end
   end

--- a/app/models/issue_update.rb
+++ b/app/models/issue_update.rb
@@ -23,6 +23,8 @@ class IssueUpdate < ActiveRecord::Base
   belongs_to :user
   belongs_to :service_status
 
+  delegate :subscribers, to: :issue
+
   random_string :identifier, :type => :hex, :length => 6, :unique => true
 
   scope :ordered, -> { order(:id => :desc) }
@@ -52,7 +54,7 @@ class IssueUpdate < ActiveRecord::Base
   end
 
   def send_notifications
-    for subscriber in issue.subscribers
+    for subscriber in subscribers
       Staytus::Email.deliver(subscriber, :new_issue_update, :issue => self.issue, :update => self)
     end
   end

--- a/app/models/issue_update.rb
+++ b/app/models/issue_update.rb
@@ -52,7 +52,7 @@ class IssueUpdate < ActiveRecord::Base
   end
 
   def send_notifications
-    for subscriber in Subscriber.verified
+    for subscriber in issue.subscribers
       Staytus::Email.deliver(subscriber, :new_issue_update, :issue => self.issue, :update => self)
     end
   end

--- a/app/models/maintenance.rb
+++ b/app/models/maintenance.rb
@@ -112,7 +112,7 @@ class Maintenance < ActiveRecord::Base
   end
 
   def subscribers
-    Subscriber.for_services(service_ids)
+    @subscribers ||= Subscriber.for_services(service_ids)
   end
 
   def send_notifications

--- a/app/models/maintenance.rb
+++ b/app/models/maintenance.rb
@@ -111,8 +111,12 @@ class Maintenance < ActiveRecord::Base
     end
   end
 
+  def subscribers
+    Subscriber.for_services(service_ids)
+  end
+
   def send_notifications
-    for subscriber in Subscriber.verified
+    for subscriber in subscribers
       Staytus::Email.deliver(subscriber, :new_maintenance, :maintenance => self)
     end
   end

--- a/app/models/maintenance_update.rb
+++ b/app/models/maintenance_update.rb
@@ -17,6 +17,8 @@ class MaintenanceUpdate < ActiveRecord::Base
   belongs_to :maintenance, :touch => true
   belongs_to :user
 
+  delegate :subscribers, to: :maintenance
+
   validates :text, :presence => true
 
   random_string :identifier, :type => :hex, :length => 6, :unique => true
@@ -33,7 +35,7 @@ class MaintenanceUpdate < ActiveRecord::Base
   end
 
   def send_notifications
-    for subscriber in maintenance.subscribers
+    for subscriber in subscribers
       Staytus::Email.deliver(subscriber, :new_maintenance_update, :maintenance => self.maintenance, :update => self)
     end
   end

--- a/app/models/maintenance_update.rb
+++ b/app/models/maintenance_update.rb
@@ -33,7 +33,7 @@ class MaintenanceUpdate < ActiveRecord::Base
   end
 
   def send_notifications
-    for subscriber in Subscriber.verified
+    for subscriber in maintenance.subscribers
       Staytus::Email.deliver(subscriber, :new_maintenance_update, :maintenance => self.maintenance, :update => self)
     end
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -36,6 +36,7 @@ class Service < ActiveRecord::Base
   has_many :active_maintenances, -> { references(:maintenances).where(:closed_at => nil).where("start_at <= ?", Time.now) }, :through => :maintenance_service_joins, :source => :maintenance
 
   scope :ordered, -> { order(:position => :asc) }
+  scope :ungrouped, -> { where(:group_id => nil) }
 
   def self.create_defaults
     Service.create!(:name => "Web Application")

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -12,6 +12,9 @@
 
 class Subscriber < ActiveRecord::Base
 
+  has_many :subscriber_service_joins, :dependent => :destroy
+  has_many :services, :through => :subscriber_service_joins
+
   validates :email_address, :presence => true, :email => true, :uniqueness => true
 
   random_string :verification_token, :type => :uuid, :unique => true
@@ -39,6 +42,13 @@ class Subscriber < ActiveRecord::Base
 
   def send_verification_email
     Staytus::Email.deliver(self, :subscribed)
+  end
+
+  def self.for_services(service_ids)
+    self.verified
+        .left_joins(:subscriber_service_joins)
+        .where('subscriber_service_joins.service_id IS NULL OR subscriber_service_joins.service_id in (?)', service_ids)
+        .group(:id)
   end
 
 end

--- a/app/models/subscriber_service_join.rb
+++ b/app/models/subscriber_service_join.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: subscriber_service_joins
+#
+#  id            :integer          not null, primary key
+#  subscriber_id :integer
+#  service_id    :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+class SubscriberServiceJoin < ActiveRecord::Base
+
+  belongs_to :subscriber
+  belongs_to :service
+
+end

--- a/app/views/admin/issues/_form.html.haml
+++ b/app/views/admin/issues/_form.html.haml
@@ -37,7 +37,7 @@
           %dd.fieldSet__input
             .fieldSet__checkbox.fieldSet__selectContainer
               = f.check_box :notify
-              = f.label :notify, "Yes - send notifications to #{pluralize Subscriber.verified.count, 'subscriber'}"
+              = f.label :notify, "Yes - send notifications to #{pluralize @issue.subscribers.count, 'subscriber'}"
 
   .formButtons
     - unless @issue.new_record?

--- a/app/views/admin/issues/_form.html.haml
+++ b/app/views/admin/issues/_form.html.haml
@@ -37,7 +37,7 @@
           %dd.fieldSet__input
             .fieldSet__checkbox.fieldSet__selectContainer
               = f.check_box :notify
-              = f.label :notify, "Yes - send notifications to #{pluralize @issue.subscribers.count, 'subscriber'}"
+              = f.label :notify, "Yes - send notifications to #{pluralize @issue.subscribers.length, 'subscriber'}"
 
   .formButtons
     - unless @issue.new_record?

--- a/app/views/admin/issues/show.html.haml
+++ b/app/views/admin/issues/show.html.haml
@@ -48,7 +48,7 @@
               %dd.fieldSet__input
                 .fieldSet__checkbox.fieldSet__selectContainer
                   = f.check_box :notify
-                  = f.label :notify, "Notify #{pluralize Subscriber.verified.count, 'subscriber'}"
+                  = f.label :notify, "Notify #{pluralize @issue.subscribers.count, 'subscriber'}"
 
       %p.u-align-right= f.submit "Post Update", :class => 'button button--solid'
 

--- a/app/views/admin/issues/show.html.haml
+++ b/app/views/admin/issues/show.html.haml
@@ -48,7 +48,7 @@
               %dd.fieldSet__input
                 .fieldSet__checkbox.fieldSet__selectContainer
                   = f.check_box :notify
-                  = f.label :notify, "Notify #{pluralize @issue.subscribers.count, 'subscriber'}"
+                  = f.label :notify, "Notify #{pluralize @issue.subscribers.length, 'subscriber'}"
 
       %p.u-align-right= f.submit "Post Update", :class => 'button button--solid'
 

--- a/app/views/admin/maintenances/_form.html.haml
+++ b/app/views/admin/maintenances/_form.html.haml
@@ -43,7 +43,7 @@
         %dd.fieldSet__input
           .fieldSet__checkbox.fieldSet__selectContainer
             = f.check_box :notify
-            = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers.count, 'subscriber'}"
+            = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers.length, 'subscriber'}"
 
   .formButtons
     - unless @maintenance.new_record?

--- a/app/views/admin/maintenances/_form.html.haml
+++ b/app/views/admin/maintenances/_form.html.haml
@@ -43,7 +43,7 @@
         %dd.fieldSet__input
           .fieldSet__checkbox.fieldSet__selectContainer
             = f.check_box :notify
-            = f.label :notify, "Yes - send notifications to #{pluralize Subscriber.verified.count, 'subscriber'}"
+            = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers.count, 'subscriber'}"
 
   .formButtons
     - unless @maintenance.new_record?

--- a/app/views/admin/maintenances/show.html.haml
+++ b/app/views/admin/maintenances/show.html.haml
@@ -49,7 +49,7 @@
           %dd.fieldSet__input
             .fieldSet__checkbox.fieldSet__selectContainer
               = f.check_box :notify
-              = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers_count, 'subscriber'}"
+              = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers.length, 'subscriber'}"
 
       %p.u-align-right= f.submit "Post Update", :class => 'button button--solid'
 

--- a/app/views/admin/maintenances/show.html.haml
+++ b/app/views/admin/maintenances/show.html.haml
@@ -49,7 +49,7 @@
           %dd.fieldSet__input
             .fieldSet__checkbox.fieldSet__selectContainer
               = f.check_box :notify
-              = f.label :notify, "Yes - send notifications to #{pluralize Subscriber.verified.count, 'subscriber'}"
+              = f.label :notify, "Yes - send notifications to #{pluralize @maintenance.subscribers_count, 'subscriber'}"
 
       %p.u-align-right= f.submit "Post Update", :class => 'button button--solid'
 

--- a/content/themes/default/assets/javascripts/default.js
+++ b/content/themes/default/assets/javascripts/default.js
@@ -26,10 +26,10 @@ $(function() {
     let checkboxGroup = $(this).parents().eq(2);
     let allServices = checkboxGroup.find("input[type=checkbox]").length
     let checkedServices = checkboxGroup.find("input[type=checkbox]:checked").length;
-      if (!checkedServices) {
-        checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", false);
-      } else if (allServices === checkedServices) {
-        checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", true);
-      }
+    if (!checkedServices) {
+      checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", false);
+    } else if (allServices === checkedServices) {
+      checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", true);
+    }
   });
 });

--- a/content/themes/default/assets/javascripts/default.js
+++ b/content/themes/default/assets/javascripts/default.js
@@ -5,12 +5,31 @@
 $(function() {
   $('time').timeago();
 
-  $('#all_services_checkbox').change(function (){
+  $('#js-allServicesCheckbox').change(function (){
     if (this.checked) {
-      $('.subscribePage__checkbox').prop('checked', false);
+      $('.subscribePage__checkbox').prop("checked", false);
       $('.subscribePage__services').hide();
     } else {
       $('.subscribePage__services').show();
     }
+  });
+
+  $('.js-serviceGroupCheckbox').change(function () {
+    $(this).parents().eq(2)
+      .find("ul")
+      .children()
+      .find("input[type=checkbox]")
+      .prop('checked', $(this).prop("checked"));
+  });
+
+  $('.subscribePage__checkboxList').on("change", ":checkbox", function () {
+    let checkboxGroup = $(this).parents().eq(2);
+    let allServices = checkboxGroup.find("input[type=checkbox]").length
+    let checkedServices = checkboxGroup.find("input[type=checkbox]:checked").length;
+      if (!checkedServices) {
+        checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", false);
+      } else if (allServices === checkedServices) {
+        checkboxGroup.parent().find(".js-serviceGroupCheckbox").prop("checked", true);
+      }
   });
 });

--- a/content/themes/default/assets/javascripts/default.js
+++ b/content/themes/default/assets/javascripts/default.js
@@ -4,4 +4,13 @@
 
 $(function() {
   $('time').timeago();
+
+  $('#all_services_checkbox').change(function (){
+    if (this.checked) {
+      $('.subscribePage__checkbox').prop('checked', false);
+      $('.subscribePage__services').hide();
+    } else {
+      $('.subscribePage__services').show();
+    }
+  });
 });

--- a/content/themes/default/assets/stylesheets/default/misc.scss
+++ b/content/themes/default/assets/stylesheets/default/misc.scss
@@ -92,6 +92,7 @@
 }
 
 .inputWithSubmit {
+  margin-bottom: 5px;
   overflow: hidden;
 }
 

--- a/content/themes/default/assets/stylesheets/default/subscribe_page.scss
+++ b/content/themes/default/assets/stylesheets/default/subscribe_page.scss
@@ -64,7 +64,20 @@
   }
 }
 
-.subscribePage__checkboxGroup {
+.subscribePage__serviceGroup {
+  margin-bottom: 10px;
+
+  .subscribePage__serviceGroup--label {
+    font-size: 13px;
+    font-weight: 600;
+  }
+}
+
+.subscribePage__checkboxList {
+  padding-left: 20px;
+}
+
+.subscribePage__checkbox {
   span, input {
     font-size: 13px;
     vertical-align: middle;

--- a/content/themes/default/assets/stylesheets/default/subscribe_page.scss
+++ b/content/themes/default/assets/stylesheets/default/subscribe_page.scss
@@ -50,6 +50,27 @@
   }
 }
 
+.subscribePage__services {
+  display: none;
+  padding: 10px;
+  background-color: #f2f4f4;
+  border: 1px solid #f2f4f4;
+  border-radius: 4px;
+  margin-top: 10px;
+
+  p {
+    font-size: 13px;
+    margin-bottom: 5px;
+  }
+}
+
+.subscribePage__checkboxGroup {
+  span, input {
+    font-size: 13px;
+    vertical-align: middle;
+  }
+}
+
 @media (max-width: 600px) {
   .subscribePage__heading {
     font-size:29px;

--- a/content/themes/default/views/pages/subscribe.html.erb
+++ b/content/themes/default/views/pages/subscribe.html.erb
@@ -22,8 +22,22 @@
             <button class='pushButton'>Subscribe</button>
           </div>
         </div>
-
-
+        <div class="subscribePage__checkboxGroup">
+          <label for="all_services_checkbox">
+            <input type="checkbox" id="all_services_checkbox" value="all" checked>
+            <span>Subscribe to all services</span>
+          </label>
+        </div>
+        <div class="subscribePage__services">
+          <% for service in Service.ordered %>
+            <div class="subscribePage__checkboxGroup">
+              <%= label_tag "service_#{service.id}" do %>
+                <%= check_box_tag 'service_ids[]', service.id, false, :id => "service_#{service.id}", :class => 'subscribePage__checkbox' %>
+                <span><%= service.name %></span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       <% end %>
     </div>
 

--- a/content/themes/default/views/pages/subscribe.html.erb
+++ b/content/themes/default/views/pages/subscribe.html.erb
@@ -22,21 +22,46 @@
             <button class='pushButton'>Subscribe</button>
           </div>
         </div>
-        <div class="subscribePage__checkboxGroup">
-          <label for="all_services_checkbox">
-            <input type="checkbox" id="all_services_checkbox" value="all" checked>
+        <div class="subscribePage__checkbox">
+          <label for="js-allServicesCheckbox">
+            <input type="checkbox" id="js-allServicesCheckbox" value="all" checked>
             <span>Subscribe to all services</span>
           </label>
         </div>
         <div class="subscribePage__services">
-          <% for service in Service.ordered %>
-            <div class="subscribePage__checkboxGroup">
-              <%= label_tag "service_#{service.id}" do %>
-                <%= check_box_tag 'service_ids[]', service.id, false, :id => "service_#{service.id}", :class => 'subscribePage__checkbox' %>
-                <span><%= service.name %></span>
-              <% end %>
+
+          <% for service_group in ServiceGroup.ordered %>
+            <div class="subscribePage__serviceGroup">
+              <div class="subscribePage__checkbox">
+                <%= label_tag "service_group_#{service_group.id}", class: 'subscribePage__serviceGroup--label' do %>
+                  <%= check_box_tag '', service_group.id, false, :id => "service_group_#{service_group.id}", :class => 'subscribePage__checkbox js-serviceGroupCheckbox' %>
+                  <span class="subscribePage__serviceGroup--heading"><%= service_group.name %></span>
+                <% end %>
+              </div>
+              <ul class="subscribePage__checkboxList">
+                <% for service in service_group.services.ordered %>
+                  <li class="subscribePage__checkbox">
+                    <%= label_tag "service_#{service.id}" do %>
+                      <%= check_box_tag 'service_ids[]', service.id, false, :id => "service_#{service.id}", :class => 'subscribePage__checkbox' %>
+                      <span><%= service.name %></span>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
             </div>
           <% end %>
+
+          <div class="subscribePage__serviceGroup">
+            <% for service in Service.ungrouped %>
+              <div class="subscribePage__checkbox">
+                <%= label_tag "service_#{service.id}" do %>
+                  <%= check_box_tag 'service_ids[]', service.id, false, :id => "service_#{service.id}", :class => 'subscribePage__checkbox' %>
+                  <span><%= service.name %></span>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
         </div>
       <% end %>
     </div>

--- a/db/migrate/20201130164954_create_subscriber_service_joins.rb
+++ b/db/migrate/20201130164954_create_subscriber_service_joins.rb
@@ -1,0 +1,8 @@
+class CreateSubscriberServiceJoins < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscriber_service_joins do |t|
+      t.integer :subscriber_id, :service_id
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425131827) do
+ActiveRecord::Schema.define(version: 20201130164954) do
 
   create_table "api_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
@@ -210,6 +210,13 @@ ActiveRecord::Schema.define(version: 20180425131827) do
     t.boolean "allow_subscriptions", default: true
     t.string "http_protocol"
     t.string "privacy_policy_url"
+  end
+
+  create_table "subscriber_service_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "subscriber_id"
+    t.integer "service_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "subscribers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
This PR allows new subscribers to choose which services they wish to subscribe to. It adds a new checkbox under the email input field which is checked by default - subscriber will receive notifications about all services; un-checking this checkbox field will open a section where subscribers can see all possible services that they might want to subscribe to.

![subs](https://user-images.githubusercontent.com/42203630/100890809-8c707200-34b0-11eb-950c-0f3c43f410a2.png)

 