### PR TITLE
feat: adds option to automatically close maintenances on completion time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'redcarpet'
 gem 'premailer'
 gem 'rack-custom-proxies'
 gem 'log_logins'
+gem 'clockwork'
 
 group :development, :test do
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
     chronic (0.10.2)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
+    clockwork (2.0.4)
+      activesupport
+      tzinfo
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -235,6 +238,7 @@ DEPENDENCIES
   bcrypt
   chronic
   chronic_duration
+  clockwork
   coffee-rails
   datey
   delayed_job_active_record

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec rake jobs:work
+cron: bundle exec clockwork config/cron.rb

--- a/app/controllers/admin/maintenances_controller.rb
+++ b/app/controllers/admin/maintenances_controller.rb
@@ -54,7 +54,7 @@ class Admin::MaintenancesController < Admin::BaseController
   private
 
   def safe_params
-    params.require(:maintenance).permit(:title, :description, :start_at_as_string, :length_in_minutes_as_string, :service_status_id, :notify, :service_ids => [])
+    params.require(:maintenance).permit(:title, :description, :start_at_as_string, :length_in_minutes_as_string, :auto_close_on_completion, :service_status_id, :notify, :service_ids => [])
   end
 
 end

--- a/app/models/maintenance.rb
+++ b/app/models/maintenance.rb
@@ -2,19 +2,20 @@
 #
 # Table name: maintenances
 #
-#  id                :integer          not null, primary key
-#  title             :string(255)
-#  description       :text(65535)
-#  start_at          :datetime
-#  finish_at         :datetime
-#  length_in_minutes :integer
-#  user_id           :integer
-#  service_status_id :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  closed_at         :datetime
-#  identifier        :string(255)
-#  notify            :boolean          default(FALSE)
+#  id                       :bigint           not null, primary key
+#  auto_close_on_completion :boolean          default(FALSE)
+#  closed_at                :datetime
+#  description              :text(65535)
+#  finish_at                :datetime
+#  identifier               :string(255)
+#  length_in_minutes        :integer
+#  notify                   :boolean          default(FALSE)
+#  start_at                 :datetime
+#  title                    :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  service_status_id        :integer
+#  user_id                  :integer
 #
 
 class Maintenance < ActiveRecord::Base
@@ -125,6 +126,10 @@ class Maintenance < ActiveRecord::Base
     if self.notify?
       self.delay.send_notifications
     end
+  end
+
+  def self.close_finished
+    self.open.where('auto_close_on_completion = true AND finish_at <= ?', Time.now.utc).update_all(:closed_at => Time.now)
   end
 
   private

--- a/app/views/admin/maintenances/_form.html.haml
+++ b/app/views/admin/maintenances/_form.html.haml
@@ -21,6 +21,8 @@
         %dl.fieldSet__field.u-margin
           %dt.fieldSet__label= f.label :length_in_minutes_as_string, "How long will this session last?"
           %dd.fieldSet__input= f.text_field :length_in_minutes_as_string, :class => 'textInput', :required => true, :placeholder => "e.g. 2 hours, 30 minutes or 6 and a half hours"
+          = f.check_box :auto_close_on_completion
+          = f.label :auto_close_on_completion, "Auto-finish on completion?"
 
     %dl.fieldSet__field.u-margin
       %dt.fieldSet__label= f.label :service_ids, "Which services are affected?"

--- a/app/views/admin/maintenances/show.html.haml
+++ b/app/views/admin/maintenances/show.html.haml
@@ -19,6 +19,9 @@
     %dt Completion Time
     %dd= @maintenance.finish_at.to_s(:long)
   %dl.definition.u-margin
+    %dt Automatic finish?
+    %dd= @maintenance.auto_close_on_completion? ? "Yes" : "No"
+  %dl.definition.u-margin
     %dt Status
     %dd= maintenance_status_tag @maintenance.status
   - unless @maintenance.services.empty?

--- a/config/cron.rb
+++ b/config/cron.rb
@@ -1,0 +1,14 @@
+require 'clockwork'
+require_relative 'environment'
+
+module Clockwork
+
+  configure do |config|
+    config[:tz] = 'UTC'
+  end
+
+  every 1.hour, 'hourly', :at => '**:00' do
+    Maintenance.close_finished
+  end
+
+end

--- a/db/migrate/20201208135052_add_auto_close_on_completion_to_maintenances.rb
+++ b/db/migrate/20201208135052_add_auto_close_on_completion_to_maintenances.rb
@@ -1,0 +1,7 @@
+class AddAutoCloseOnCompletionToMaintenances < ActiveRecord::Migration[5.2]
+
+  def change
+    add_column :maintenances, :auto_close_on_completion, :boolean, default: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201130164954) do
+ActiveRecord::Schema.define(version: 2020_12_08_135052) do
 
-  create_table "api_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "api_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "token"
     t.string "secret"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "authie_sessions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "authie_sessions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "token"
     t.string "browser_id"
     t.integer "user_id"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.index ["user_id"], name: "index_authie_sessions_on_user_id"
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "email_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "email_templates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "subject"
     t.text "content"
@@ -72,20 +72,20 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "history_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "history_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "item_type"
     t.integer "item_id"
     t.datetime "date"
   end
 
-  create_table "issue_service_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "issue_service_joins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "issue_id"
     t.integer "service_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "issue_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "issue_updates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "issue_id"
     t.integer "user_id"
     t.integer "service_status_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.boolean "notify", default: false
   end
 
-  create_table "issues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "issues", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "state"
     t.integer "service_status_id"
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.boolean "notify", default: false
   end
 
-  create_table "login_events", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "login_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "user_type"
     t.integer "user_id"
     t.string "username"
@@ -119,21 +119,21 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.string "user_agent"
     t.datetime "created_at"
     t.index ["created_at"], name: "index_login_events_on_created_at"
-    t.index ["interface"], name: "index_login_events_on_interface", length: { interface: 10 }
+    t.index ["interface"], name: "index_login_events_on_interface", length: 10
     t.index ["ip", "id"], name: "index_login_events_on_ip_and_id", length: { ip: 50 }
-    t.index ["ip"], name: "index_login_events_on_ip", length: { ip: 10 }
+    t.index ["ip"], name: "index_login_events_on_ip", length: 10
     t.index ["user_id", "id"], name: "index_login_events_on_user_id_and_id"
     t.index ["user_type", "user_id"], name: "index_login_events_on_user_type_and_user_id", length: { user_type: 10 }
   end
 
-  create_table "maintenance_service_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "maintenance_service_joins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "maintenance_id"
     t.integer "service_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "maintenance_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "maintenance_updates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "maintenance_id"
     t.integer "user_id"
     t.text "text"
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.boolean "notify", default: false
   end
 
-  create_table "maintenances", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "maintenances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "start_at"
@@ -156,9 +156,10 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "closed_at"
     t.string "identifier"
     t.boolean "notify", default: false
+    t.boolean "auto_close_on_completion", default: false
   end
 
-  create_table "nifty_attachments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "nifty_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "parent_id"
     t.string "parent_type"
     t.string "token"
@@ -171,13 +172,13 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "updated_at"
   end
 
-  create_table "service_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "service_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "service_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "service_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "permalink"
     t.string "color"
@@ -186,7 +187,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "permalink"
     t.integer "position"
@@ -197,7 +198,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.integer "group_id"
   end
 
-  create_table "sites", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "sites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "description"
     t.string "domain"
@@ -212,14 +213,14 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.string "privacy_policy_url"
   end
 
-  create_table "subscriber_service_joins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "subscriber_service_joins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "subscriber_id"
     t.integer "service_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "subscribers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "subscribers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email_address"
     t.string "verification_token"
     t.datetime "verified_at"
@@ -227,7 +228,7 @@ ActiveRecord::Schema.define(version: 20201130164954) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email_address"
     t.string "name"
     t.string "password_digest"


### PR DESCRIPTION
This PR adds functionality to close a **finished** maintenance which is currently set as **open** in Staytus
Details: 
-  Added the clockwork gem to schedule a cron job within the app that handles the updates 
-  Maintenance updates are triggered every hour