### PR TITLE
Update bcrypt dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       rake (>= 10.4, < 14.0)
     arel (9.0.0)
     authie (3.1.5)
-    bcrypt (3.1.11)
+    bcrypt (3.1.16)
     builder (3.2.4)
     chronic (0.10.2)
     chronic_duration (0.10.6)


### PR DESCRIPTION
Fix #348 and BCrypt::Errors::InvalidHash (invalid hash) error 500 while creating the first user on a fresh setup.